### PR TITLE
Project setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 css
 js
 node_modules
+.idea
+.DS_Store

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,7 +3,8 @@ var gutil = require('gulp-util');
 var notify = require('gulp-notify');
 var less = require('gulp-less');
 var autoprefix = require('gulp-autoprefixer');
-var minifyCSS = require('gulp-minify-css')
+var minifyCSS = require('gulp-minify-css');
+var connect = require('gulp-connect');
 
 //Pre-compiled directory
 var lessDir = 'src/less';
@@ -22,4 +23,11 @@ gulp.task('watch', function () {
     gulp.watch(lessDir + '/*.less', ['css']);
 });
 
-gulp.task('default', ['css', 'watch']);
+gulp.task('connect', function() {
+    connect.server({
+        root: '.',
+        livereload: true
+    })
+});
+
+gulp.task('default', ['css', 'watch', 'connect']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,25 @@
+var gulp = require('gulp');
+var gutil = require('gulp-util');
+var notify = require('gulp-notify');
+var less = require('gulp-less');
+var autoprefix = require('gulp-autoprefixer');
+var minifyCSS = require('gulp-minify-css')
+
+//Pre-compiled directory
+var lessDir = 'src/less';
+
+//Compiled directory
+var targetCSSDir = 'css/';
+
+gulp.task('css', function () {
+    return gulp.src(lessDir + '/*.less')
+        .pipe(less({ style: 'compressed' }).on('error', gutil.log))
+        .pipe(gulp.dest(targetCSSDir))
+        .pipe(notify('CSS minified'))
+});
+
+gulp.task('watch', function () {
+    gulp.watch(lessDir + '/*.less', ['css']);
+});
+
+gulp.task('default', ['css', 'watch']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ var less = require('gulp-less');
 var autoprefix = require('gulp-autoprefixer');
 var minifyCSS = require('gulp-minify-css');
 var connect = require('gulp-connect');
+var livereload = require('gulp-livereload');
 
 //Pre-compiled directory
 var lessDir = 'src/less';
@@ -17,9 +18,11 @@ gulp.task('css', function () {
         .pipe(less({ style: 'compressed' }).on('error', gutil.log))
         .pipe(gulp.dest(targetCSSDir))
         .pipe(notify('CSS minified'))
+        .pipe(livereload())
 });
 
 gulp.task('watch', function () {
+    livereload.listen();
     gulp.watch(lessDir + '/*.less', ['css']);
 });
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "browserify": "^13.1.0",
     "flux": "^3.0.0",
     "grunt-cli": "^1.2.0",
+    "gulp-livereload": "^3.8.1",
     "keymirror": "^0.1.1",
     "less": "^2.7.1",
     "lodash.clonedeep": "^4.5.0",


### PR DESCRIPTION
Various tasks to prepare the project to implement the code coverage insights page.

- Updated the `.gitignore` for macOS and JetBrains development
- Gulp:
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- The project in its current state uses `npm` to run it's builds. There are some issues with the current build commands (see Issue #3 for more details).
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- Implemented a basic Gulp file
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- Created a task for Less compilation
&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- Created a watch task and also added _gulp-livereload_ (well... for live reloading :stuck_out_tongue:)