### PR TITLE
Revision selector

### DIFF
--- a/src/actions/PageActions.js
+++ b/src/actions/PageActions.js
@@ -46,10 +46,17 @@ var PageActions = {
       actionType: PageConstants.SET_SELECTED,
       set: q
     });
-  }, 
+  },
+
   setRevision: function(q) {
     AppDispatcher.dispatch({
       actionType: PageConstants.SET_REVISION,
+      set: q
+    });
+  },
+  setRevisionList: function(q) {
+    AppDispatcher.dispatch({
+      actionType: PageConstants.SET_REVISION_LIST,
       set: q
     });
   }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -41,7 +41,8 @@ var RevisionSetter = React.createClass({
   renderRevisions: function() {
       var revision_list = [];
       for (var i in this.state.revision_list) {
-          var buildDate = this.state.revision_list[i].build.date;
+
+          var buildDate = new Date(this.state.revision_list[i].build.date * 1000).toISOString();
           var buildRevision = this.state.revision_list[i].build.revision12;
           var buildCount = this.state.revision_list[i].count;
 
@@ -63,11 +64,6 @@ var RevisionSetter = React.createClass({
             <Button onClick={this.doSet}>Set</Button>
           </InputGroup.Button>
         </InputGroup>
-        {/*<ButtonToolbar>*/}
-          {/*<DropdownButton bsSize="large" title="Revision ID" id="dropdown-size-large">*/}
-              {/*{this.renderRevisions()}*/}
-          {/*</DropdownButton>*/}
-        {/*</ButtonToolbar>*/}
         <ControlLabel>Select Revision (Last 2 months)</ControlLabel>
         <FormControl onChange={this.handleR} value={this.state.value}  onClick={this.doSet} componentClass="select">
           <option>Select a revision...</option>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -34,18 +34,21 @@ var RevisionSetter = React.createClass({
   },
   handleR: function(e) {
     this.setState({revision: e.target.value});
+    PageActions.setRevision(e.target.value);
   },
   doSet: function() {
     PageActions.setRevision(this.state.revision);
   },
+  doSetByRevisionList: function (e) {
+      this.setState({revision: e.target.value});
+      PageActions.setRevision(e.target.value);
+  },
   renderRevisions: function() {
       var revision_list = [];
       for (var i in this.state.revision_list) {
-
           var buildDate = new Date(this.state.revision_list[i].build.date * 1000).toISOString();
           var buildRevision = this.state.revision_list[i].build.revision12;
           var buildCount = this.state.revision_list[i].count;
-
           revision_list.push(
             <option value={buildRevision}>
               {buildDate} | {buildRevision} | {buildCount}
@@ -64,10 +67,11 @@ var RevisionSetter = React.createClass({
             <Button onClick={this.doSet}>Set</Button>
           </InputGroup.Button>
         </InputGroup>
+        <br/>
         <ControlLabel>Select Revision (Last 2 months)</ControlLabel>
-        <FormControl onChange={this.handleR} value={this.state.value}  onClick={this.doSet} componentClass="select">
-          <option>Select a revision...</option>
-            {this.renderRevisions()}
+        <FormControl onChange={this.doSetByRevisionList} value={this.state.value} componentClass="select">
+          <option selected="selected" disabled>Select a revision...</option>
+          {this.renderRevisions()}
         </FormControl>
       </FormGroup>
     );

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -39,7 +39,7 @@ var RevisionSetter = React.createClass({
     PageActions.setRevision(this.state.revision);
   },
   render: function() {
-    debugger
+    //TODO Populate dropdown with date/revision/count
     console.log(this.state.revision_list);
     return (
       <FormGroup>

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -38,9 +38,21 @@ var RevisionSetter = React.createClass({
   doSet: function() {
     PageActions.setRevision(this.state.revision);
   },
+  renderRevisions: function() {
+      var revision_list = [];
+      for (var i in this.state.revision_list) {
+          var buildDate = this.state.revision_list[i].build.date;
+          var buildRevision = this.state.revision_list[i].build.revision12;
+          var buildCount = this.state.revision_list[i].count;
+
+          revision_list.push(
+            <option value={buildRevision}>
+              {buildDate} | {buildRevision} | {buildCount}
+            </option>);
+      }
+      return revision_list;
+  },
   render: function() {
-    //TODO Populate dropdown with date/revision/count
-    console.log(this.state.revision_list);
     return (
       <FormGroup>
         <ControlLabel>Revision ID</ControlLabel>
@@ -51,13 +63,16 @@ var RevisionSetter = React.createClass({
             <Button onClick={this.doSet}>Set</Button>
           </InputGroup.Button>
         </InputGroup>
-        <ButtonToolbar>
-          <DropdownButton bsSize="large" title="Revision ID" id="dropdown-size-large">
-            <MenuItem eventKey="1">4253e14676c2</MenuItem>
-            <MenuItem eventKey="2">6d1633095a92</MenuItem>
-            <MenuItem eventKey="3">26ced60e971a</MenuItem>
-          </DropdownButton>
-        </ButtonToolbar>
+        {/*<ButtonToolbar>*/}
+          {/*<DropdownButton bsSize="large" title="Revision ID" id="dropdown-size-large">*/}
+              {/*{this.renderRevisions()}*/}
+          {/*</DropdownButton>*/}
+        {/*</ButtonToolbar>*/}
+        <ControlLabel>Select Revision (Last 2 months)</ControlLabel>
+        <FormControl onChange={this.handleR} value={this.state.value}  onClick={this.doSet} componentClass="select">
+          <option>Select a revision...</option>
+            {this.renderRevisions()}
+        </FormControl>
       </FormGroup>
     );
   }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -11,7 +11,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import {Button, Nav, NavItem, MenuItem, NavDropdown, ControlLabel,
-FormControl, InputGroup, FormGroup} from 'react-bootstrap';
+FormControl, InputGroup, FormGroup, ButtonToolbar, DropdownButton} from 'react-bootstrap';
 
 import InfoModal from './InfoModal';
 import ClientConstants from '../client/ClientConstants';
@@ -49,6 +49,13 @@ var RevisionSetter = React.createClass({
             <Button onClick={this.doSet}>Set</Button>
           </InputGroup.Button>
         </InputGroup>
+        <ButtonToolbar>
+          <DropdownButton bsSize="large" title="Revision ID" id="dropdown-size-large">
+            <MenuItem eventKey="1">4253e14676c2</MenuItem>
+            <MenuItem eventKey="2">6d1633095a92</MenuItem>
+            <MenuItem eventKey="3">26ced60e971a</MenuItem>
+          </DropdownButton>
+        </ButtonToolbar>
       </FormGroup>
     );
   }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -21,7 +21,7 @@ import PageActions from '../actions/PageActions';
 
 var RevisionSetter = React.createClass({
   getInitialState: function() {
-    return {revision: PageStore.getRevision()} 
+    return {revision: PageStore.getRevision(), revision_list: PageStore.getRevisionList()}
   },
   componentDidMount: function() {
     PageStore.addChangeListener(this._onChange, 'query');
@@ -39,6 +39,8 @@ var RevisionSetter = React.createClass({
     PageActions.setRevision(this.state.revision);
   },
   render: function() {
+    debugger
+    console.log(this.state.revision_list);
     return (
       <FormGroup>
         <ControlLabel>Revision ID</ControlLabel>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -148,17 +148,18 @@ var TopLevel = React.createClass({
     PageStore.addChangeListener(this._onChange);
     // Get latest query
     Client.makeRequest('activedata.allizom.org', {
+      "sort":{"build.date":"desc"},
       "from":"coverage-summary",
-      "limit":10,
-      "groupby":["build.date","build.revision12"]
+      "limit":1000,
+      "groupby":["build.date","build.revision12"],
+      "where":{"gte":{"build.date":{"date":"today-2month"}}}
     },
     (data) => {
-      //TODO(brad) this needs to be sorted by build.date not count
       PageActions.setRevision(data.data[0][1]);
 
       var revision_list = [];
       for (var i in data.data) {
-        revision_list.push(data.data[i][1])
+        revision_list.push(data.data[i][0])
       };
       PageActions.setRevisionList(revision_list);
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -155,6 +155,13 @@ var TopLevel = React.createClass({
     (data) => {
       //TODO(brad) this needs to be sorted by build.date not count
       PageActions.setRevision(data.data[0][1]);
+
+      var revision_list = [];
+      for (var i in data.data) {
+        revision_list.push(data.data[i][1])
+      };
+      PageActions.setRevisionList(revision_list);
+
       this.setState({loading: false});
 
       if (Config.DEVON) {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -152,14 +152,15 @@ var TopLevel = React.createClass({
       "from":"coverage-summary",
       "limit":1000,
       "groupby":["build.date","build.revision12"],
-      "where":{"gte":{"build.date":{"date":"today-2month"}}}
+      "where":{"gte":{"build.date":{"date":"today-2month"}}},
+      "format":"list"
     },
     (data) => {
-      PageActions.setRevision(data.data[0][1]);
+      PageActions.setRevision(data.data[0].build.revision12);
 
       var revision_list = [];
       for (var i in data.data) {
-        revision_list.push(data.data[i][0])
+        revision_list.push(data.data[i])
       };
       PageActions.setRevisionList(revision_list);
 

--- a/src/constants/PageConstants.js
+++ b/src/constants/PageConstants.js
@@ -21,5 +21,6 @@ module.exports = keyMirror({
   UPDATE_QUERY: null,
   SET_CONTEXT: null,
   SET_SELECTED: null,
-  SET_REVISION: null
+  SET_REVISION: null,
+  SET_REVISION_LIST: null
 });

--- a/src/stores/PageStore.js
+++ b/src/stores/PageStore.js
@@ -19,6 +19,7 @@ const DRILL_EVENT = 'drill';
 var _selected = null;
 var _context = null;
 var _revision = null;
+var _revisionList = null;
 var _pages = {};
 var _current_page = 0;
 var _id_incrementor = 0;
@@ -67,6 +68,11 @@ function setRevision(q) {
   _revision = q;
 }
 
+function setRevisionList(q) {
+  _revisionList = q;
+}
+
+
 var PageStore = Object.assign({}, EventEmitter.prototype, {
   
   getQuery: function() {
@@ -91,6 +97,10 @@ var PageStore = Object.assign({}, EventEmitter.prototype, {
   
   getRevision: function() {
     return _revision;
+  },
+
+  getRevisionList: function() {
+    return _revisionList;
   },
 
   emitChange: function(evnt = CHANGE_EVENT) {
@@ -135,6 +145,10 @@ AppDispatcher.register(function(action) {
       break; 
     case PageConstants.SET_REVISION:
       setRevision(action.set);
+      PageStore.emitChange(QUERY_EVENT);
+      break;
+    case PageConstants.SET_REVISION_LIST:
+      setRevisionList(action.set);
       PageStore.emitChange(QUERY_EVENT);
       break;
     default:


### PR DESCRIPTION
### Use case to solve
Currently users must manually copy and paste a revision in the revision input text box. We want to users to have the ability to quickly switch between revisions (without the copy and pasting). Ultimately, the selector will be used in future components of the application.

### Implementation details
- Added the revisionList code the application's `PageConstants`, `PageActions` and `PageStores`.
- Updated the ActiveData query in `index.js` with:
   - Descending build date
   - Limit revisions to the last two months
   - Request returns objects instead of tuples
- Refactored code from the previous implementation to work with the updated ActiveData query
- I left the existing revision input in case a user wants to set the revision manually

### Future work
- Create a separate component for the revision selector list and include it in the `Sidebar.js` component
- Implement [React-Select](https://jedwatson.github.io/react-select/). I tried implementing this plugin and ran into a few issues. I might attempt to implement it later in the project.

### See it in action
![revision_selector](https://cloud.githubusercontent.com/assets/6282512/23466495/a6d0f2d8-fe71-11e6-964f-5bdbc726b8f6.gif)

### Screenshot
<img width="489" alt="screen shot 2017-02-28 at 11 49 47 am" src="https://cloud.githubusercontent.com/assets/6282512/23412485/0fd46718-fdac-11e6-958f-8b30b7ffadf4.png">
