### PR TITLE
Added language indicator on revision dropdown

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -39,13 +39,25 @@ var RevisionSetter = React.createClass({
   renderRevisions: function() {
       var revision_list = [];
       for (var i in this.state.revision_list) {
+          // debugger;
           var buildDate = new Date(this.state.revision_list[i].build.date * 1000).toISOString();
           var buildRevision = this.state.revision_list[i].build.revision12;
           var buildCount = this.state.revision_list[i].count;
-          revision_list.push(
-            <option value={buildRevision}>
-              {buildDate} | {buildRevision} | {buildCount}
-            </option>);
+          var buildLanguage = "";
+          try {
+              buildLanguage = this.state.revision_list[i].source.language;
+          } catch(e) {}
+          if(buildLanguage){
+              revision_list.push(
+                <option value={buildRevision}>
+                    {buildDate} | {buildRevision} | {buildCount} | {buildLanguage}
+                </option>);
+          } else {
+              revision_list.push(
+                <option value={buildRevision}>
+                    {buildDate} | {buildRevision} | {buildCount}
+                </option>);
+          }
       }
       return revision_list;
   },

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -39,7 +39,6 @@ var RevisionSetter = React.createClass({
   renderRevisions: function() {
       var revision_list = [];
       for (var i in this.state.revision_list) {
-          // debugger;
           var buildDate = new Date(this.state.revision_list[i].build.date * 1000).toISOString();
           var buildRevision = this.state.revision_list[i].build.revision12;
           var buildCount = this.state.revision_list[i].count;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -146,12 +146,12 @@ var TopLevel = React.createClass({
   },
   componentWillMount: function() {
     PageStore.addChangeListener(this._onChange);
-    // Get latest query
+    // Get latest revision query (last two months)
     Client.makeRequest('activedata.allizom.org', {
       "sort":{"build.date":"desc"},
       "from":"coverage-summary",
       "limit":1000,
-      "groupby":["build.date","build.revision12"],
+      "groupby":["build.date","build.revision12","source.language"],
       "where":{"gte":{"build.date":{"date":"today-2month"}}},
       "format":"list"
     },


### PR DESCRIPTION
For issue #25 

- Updated the revision selector to include language
- Appended "source.language" property to the current query [see  in ActiveData](https://activedata.allizom.org/tools/query.html#query_id=yIx3cwyz)
- Account for instances that there is no `source.language` for a given revision

**Screenshot**
<img width="442" alt="screen shot 2017-03-28 at 3 24 48 pm" src="https://cloud.githubusercontent.com/assets/6282512/24420888/c4520ffe-13ca-11e7-95ae-992f74ea8874.png">
